### PR TITLE
Changes to README and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QuantumOptics.jl website
 
-* **QuantumOptics.jl-benchmarks** generates json files containing the results of the benchmarks and provides the source code of the examples. For now, the fodler *benchmark-data* is managed by Git, although it can be generated from the *benchmarks* repo if needed. This is a convenience method.
+* **QuantumOptics.jl-benchmarks** generates JSON files containing the results of the benchmarks and provides the source code of the examples. For now, the folder *benchmark-data* is managed by Git, although it can be generated from the *benchmarks* repo if needed. This is a convenience method.
 
 In this repository the following additional resources are defined:
 * A common header used in every single page.
@@ -9,21 +9,21 @@ In this repository the following additional resources are defined:
 * The main page.
 * **QuantumOptics.jl** code snippets which are shown in the main page.
 * Citation page.
-* Benchmark page presenting the data and source-code obtained from **QuantumOptics.jl-benchmarks**
+* Benchmark page presenting the data and source-code obtained from **QuantumOptics.jl-benchmarks**.
 
 [Jekyll](https://jekyllrb.com) is used to generate the (static) website from all different parts.
 
 The website itself uses the following technologies:
 
-JavaScript libraries:
+**JavaScript libraries**
 * **jquery.js**
 * **Require.js**
 * **Bootstrap.js** for the layout.
-* **MathJax.js** for representing latex formulas.
+* **MathJax.js** for representing LaTeX formulas.
 * **highlight.js** to dynamically highlight the source code.
 * **Chart.js** for the interactive benchmark plots.
 
-CSS:
+**CSS**
 * **Bootstrap.css**
 * **font-awesome**
 * **Lato|Ubuntu+Mono**
@@ -55,5 +55,6 @@ It is recommended to place all resources into the same directory, i.e.:
 The code snippets are executed by make.jl.
 
 Finally, one uses jekyll to build the website:
-    * For development run jekyll interactively: `jekyll serve`.
-    * To just create it once: `jekyll build`. This will create the finished website in the `build` directory which then can be deployed to the server.
+
+* For development, run jekyll interactively: `jekyll serve`.
+* To just create it once: `jekyll build`. This will create the finished website in the `build` directory which then can be deployed to the server.

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@ layout: default
          <img src="images/logo.png" class="img-responsive">
              </div>
          </div>
-         <h2>A Julia Framework for Open Quantum Dynamics</h2>
+         <h2>A Julia Framework for Quantum Dynamics</h2>
         </div>
     </header>
 
@@ -22,7 +22,7 @@ layout: default
 
             <div class="col-md-10 col-md-offset-1">
 
-                <p class="lead text-center text-muted">QuantumOptics.jl is a numerical framework written in the <a href="http://www.julialang.org">Julia</a> programming language that makes it easy to simulate various kinds of open quantum systems. It is inspired by the <a href="http://qo.phy.auckland.ac.nz/toolbox/">Quantum Optics Toolbox</a> for MATLAB and the Python framework <a href="http://www.qutip.org">QuTiP</a>.</p>
+                <p class="lead text-center text-muted">QuantumOptics.jl is a numerical framework written in the <a href="http://www.julialang.org">Julia</a> programming language that makes it easy to simulate various kinds of closed and open quantum systems. It is inspired by the <a href="http://qo.phy.auckland.ac.nz/toolbox/">Quantum Optics Toolbox</a> for MATLAB and the Python framework <a href="http://www.qutip.org">QuTiP</a>.</p>
 
             </div>
         </div>
@@ -34,7 +34,7 @@ layout: default
                     <i class="fa fa-inverse fa-line-chart fa-stack-1x"></i>
                 </span>
                 <h3>Performance</h3>
-                <p class="text-left text-muted">QuantumOptics.jl optimizes processor usage and memory consumption by relying on different ways to store and work with operators. Check out the <a href="benchmarks">benchmarks</a>.</p>
+                <p class="text-left text-muted">QuantumOptics.jl optimizes processor usage and memory consumption by making efficient choices for storage and use of operators. Check out the <a href="benchmarks">benchmarks</a>.</p>
             </div>
             <div class="col-md-4">
                 <span class="fa-stack fa-lg" id="feature2">
@@ -50,7 +50,7 @@ layout: default
                     <i class="fa fa-inverse fa-cogs fa-stack-1x"></i>
                 </span>
                 <h3>Reliability</h3>
-                <p class="text-left text-muted">Every function in the framework has been severely tested with all tests and their code coverage presented on the framework's <a href="https://github.com/qojulia/QuantumOptics.jl">GitHub page</a>.</p>
+                <p class="text-left text-muted">Every function in the framework has been rigorously tested, with all tests and their code coverage presented on the framework's <a href="https://github.com/qojulia/QuantumOptics.jl">GitHub page</a>.</p>
             </div>
 
 
@@ -60,7 +60,7 @@ layout: default
             <div class="col-lg-12">
                 <h2 class="page-header"><i class="fa fa-arrow-circle-right"></i> Getting Started</h2>
 
-                <p>To get started with Julia, check out <a href="https://docs.julialang.org/en/stable/manual/getting-started/">Julia's setup instructions</a>. For plotting we recommend <a href="https://matplotlib.org">matplotlib</a> in Python, which plays nicely with Julia. Before you can execute any of the framework's functions, you will need to add the <code>QuantumOptics</code> package to Julia, as shown below. Plotting with matplotlib is then enabled by adding the <code>PyPlot</code> package. To install packages, you simply need to start Julia and press the <code>]</code> key to enter the package manager (see also the <a href="https://docs.julialang.org/en/v1/stdlib/Pkg/index.html#Getting-Started-1">Julia docs</a>). Then you can add packages as follows.</p>
+                <p>To get started with Julia, check out <a href="https://docs.julialang.org/en/stable/manual/getting-started/">Julia's setup instructions</a>. For plotting, we recommend <a href="https://matplotlib.org">matplotlib</a> in Python, which plays nicely with Julia. Before you can execute any of the framework's functions, you will need to add the <code>QuantumOptics</code> package to Julia, as shown below. Plotting with matplotlib is then enabled by adding the <code>PyPlot</code> package. To install packages, you simply need to start Julia and press the <code>]</code> key to enter the package manager (see also the <a href="https://docs.julialang.org/en/v1/stdlib/Pkg/index.html#Getting-Started-1">Julia docs</a>). Then you can add packages as follows:</p>
 
                 <pre><code class="language-julia">|pkg> add QuantumOptics   # Install QuantumOptics.jl package
 |pkg> add PyPlot	  # Support for matplotlib from within Julia</code></pre>
@@ -105,7 +105,7 @@ layout: default
         </div>
         <div class="row">
             <div class="col-md-12">
-                <p>Besides the above quick start code snippets QuantumOptics.jl comes with an <a href="https://docs.qojulia.org" target="_blank">extensive documentation and many detailed examples</a>.</p>
+                <p>Besides the above quick start code snippets, QuantumOptics.jl comes with an <a href="https://docs.qojulia.org" target="_blank">extensive documentation and many detailed examples</a>.</p>
             </div>
 
         </div>


### PR DESCRIPTION
Hi, 

I'm familiarizing myself with the project so I can get into https://github.com/qojulia/QuantumOptics.jl/issues/407 with a clear idea, and came across some potential changes:

* Minor changes to README (typo fix, formatting, punctuation)
* Changes to index.html
  * Since the Github repo's About section says "Library for the numerical simulation of closed as well as open quantum systems", I removed "Open" from the main subtitle and also changed "various kinds of open quantum systems" in the description below that to "various kinds of closed and open quantum systems". Please let me know if this change is not warranted. 
  * The phrasing of "by relying on different ways to store and work with operators" and "severely tested" sounded a little bit awkward, so I replaced those with more natural sounding wording.
  * Other than the above, just some very minor punctuation fixes. 

I was planning on fixing the version number too, but the repo source says 1.0.1 while the website clearly says 1.2.1, so I'm assuming that's updated by a build script (that's not in the repo) somewhere along the way, so I'm leaving it as it is. 